### PR TITLE
fix: Register config defaults so db_table_name resolves

### DIFF
--- a/src/UserDevicesServiceProvider.php
+++ b/src/UserDevicesServiceProvider.php
@@ -14,7 +14,7 @@ class UserDevicesServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        $this->mergeConfigFrom(__DIR__.'/../config/user-devices.php', 'user-devices');
     }
 
     /**


### PR DESCRIPTION
## Problem
`UserDevicesServiceProvider::register()` never calls `mergeConfigFrom`, so `config('user-devices.db_table_name')` is `null` at runtime unless the host app publishes the config. Consumers that read the key without a fallback (e.g. the syncables sync-states foreign key) fail migration with an empty table name.

## Fix
Merge the package config in `register()` so the documented defaults (including `db_table_name => 'devices'`) are always available.

Closes #15